### PR TITLE
fix: auto-chunk date ranges exceeding 12 months in list_migrations/list_contracts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "voltarium"
-version = "0.5.4"
+version = "0.5.5"
 description = "Asynchronous Python client for CCEE (Brazilian Electric Energy Commercialization Chamber) API"
 authors = [
     { name = "joaodaher", email = "joao@daher.dev" }

--- a/src/voltarium/client.py
+++ b/src/voltarium/client.py
@@ -62,6 +62,40 @@ def _split_datetime_range_by_month(start_str: str, end_str: str) -> list[tuple[s
     return ranges
 
 
+def _split_month_range(initial_month: str, final_month: str, max_months: int = 12) -> list[tuple[str, str]]:
+    """Split a YYYY-MM range into chunks of at most *max_months* months.
+
+    CCEE's migrations and contracts endpoints reject requests whose date range
+    exceeds 12 months (ERR_MES_REFERENCIA_INICIAL_DIFERENCA).  This helper
+    transparently chunks the caller's range so the client can issue multiple
+    requests without the caller needing to know about the limit.
+    """
+    from datetime import date  # noqa: PLC0415
+
+    def _parse(s: str) -> date:
+        y, m = map(int, s.split("-"))
+        return date(y, m, 1)
+
+    def _add_months(d: date, n: int) -> date:
+        """Advance a first-of-month date by n months."""
+        result = d
+        for _ in range(n):
+            result = (result.replace(day=28) + timedelta(days=4)).replace(day=1)
+        return result
+
+    start = _parse(initial_month)
+    end = _parse(final_month)
+
+    ranges: list[tuple[str, str]] = []
+    cur = start
+    while cur <= end:
+        window_end = min(_add_months(cur, max_months - 1), end)
+        ranges.append((cur.strftime("%Y-%m"), window_end.strftime("%Y-%m")))
+        cur = _add_months(window_end, 1)
+
+    return ranges
+
+
 class VoltariumClient:
     """Asynchronous client for CCEE API."""
 
@@ -254,49 +288,40 @@ class VoltariumClient:
         Returns:
             AsyncGenerator of migrations
         """
-        # Create headers model
         headers_model = ApiHeaders(
             agent_code=str(agent_code),
             profile_code=str(profile_code),
         )
 
-        # Create parameters model
-        params_model = ListMigrationsParams(
-            initial_reference_month=initial_reference_month,
-            final_reference_month=final_reference_month,
-            retailer_profile_code=str(profile_code),
-            consumer_unit_code=consumer_unit_code,
-            migration_status=migration_status,
-        )
-
-        async def _get_page(page_index: str | None = None) -> Response:
-            # Update the page index if provided
-            if page_index is not None:
-                params_model.next_page_index = page_index
-            else:
-                params_model.next_page_index = None
-
-            return await self._request(
-                method="GET",
-                path="/v1/varejista/migracoes",
-                headers=headers_model.model_dump(by_alias=True),
-                params=params_model.model_dump(by_alias=True, exclude_none=True),
+        for window_start, window_end in _split_month_range(initial_reference_month, final_reference_month):
+            params_model = ListMigrationsParams(
+                initial_reference_month=window_start,
+                final_reference_month=window_end,
+                retailer_profile_code=str(profile_code),
+                consumer_unit_code=consumer_unit_code,
+                migration_status=migration_status,
             )
 
-        # Handle pagination
-        page_index = None
-        while True:
-            response = await _get_page(page_index)
-            data = response.json()
+            async def _get_page(page_index: str | None = None, _params=params_model) -> Response:
+                _params.next_page_index = page_index
+                return await self._request(
+                    method="GET",
+                    path="/v1/varejista/migracoes",
+                    headers=headers_model.model_dump(by_alias=True),
+                    params=_params.model_dump(by_alias=True, exclude_none=True),
+                )
 
-            # Yield migrations from current page
-            for migration_data in data.get("migracao", []):
-                yield MigrationListItem.model_validate(migration_data)
+            page_index = None
+            while True:
+                response = await _get_page(page_index)
+                data = response.json()
 
-            # Check if there are more pages
-            page_index = data.get("indexProximaPagina")
-            if page_index is None:
-                break
+                for migration_data in data.get("migracao", []):
+                    yield MigrationListItem.model_validate(migration_data)
+
+                page_index = data.get("indexProximaPagina")
+                if page_index is None:
+                    break
 
     async def create_migration(
         self,
@@ -447,35 +472,32 @@ class VoltariumClient:
             profile_code=str(profile_code),
         )
 
-        params_model = ListContractsParams(
-            initial_reference_month=initial_reference_month,
-            final_reference_month=final_reference_month,
-            retailer_profile_code=str(profile_code),
-            utility_agent_code=str(utility_agent_code) if utility_agent_code is not None else None,
-            consumer_unit_code=consumer_unit_code,
-            contract_status=contract_status,
-        )
-
-        async def _get_page(page_index: str | None = None) -> Response:
-            if page_index is not None:
-                params_model.next_page_index = page_index
-            else:
-                params_model.next_page_index = None
-
-            return await self._request(
-                method="GET",
-                path="/v1/varejista/contratos",
-                headers=headers_model.model_dump(by_alias=True),
-                params=params_model.model_dump(by_alias=True, exclude_none=True),
+        for window_start, window_end in _split_month_range(initial_reference_month, final_reference_month):
+            params_model = ListContractsParams(
+                initial_reference_month=window_start,
+                final_reference_month=window_end,
+                retailer_profile_code=str(profile_code),
+                utility_agent_code=str(utility_agent_code) if utility_agent_code is not None else None,
+                consumer_unit_code=consumer_unit_code,
+                contract_status=contract_status,
             )
 
-        page_index = None
-        while True:
-            response = await _get_page(page_index)
-            data = response.json()
+            async def _get_page(page_index: str | None = None, _params=params_model) -> Response:
+                _params.next_page_index = page_index
+                return await self._request(
+                    method="GET",
+                    path="/v1/varejista/contratos",
+                    headers=headers_model.model_dump(by_alias=True),
+                    params=_params.model_dump(by_alias=True, exclude_none=True),
+                )
 
-            for contract_data in data.get("contratos", data.get("contrato", [])):
-                yield Contract.model_validate(contract_data)
+            page_index = None
+            while True:
+                response = await _get_page(page_index)
+                data = response.json()
+
+                for contract_data in data.get("contratos", data.get("contrato", [])):
+                    yield Contract.model_validate(contract_data)
 
             page_index = data.get("indexProximaPagina")
             if page_index is None:

--- a/src/voltarium/client.py
+++ b/src/voltarium/client.py
@@ -69,7 +69,13 @@ def _split_month_range(initial_month: str, final_month: str, max_months: int = 1
     exceeds 12 months (ERR_MES_REFERENCIA_INICIAL_DIFERENCA).  This helper
     transparently chunks the caller's range so the client can issue multiple
     requests without the caller needing to know about the limit.
+
+    Raises:
+        ValueError: if max_months < 1 or initial_month is after final_month.
     """
+    if max_months < 1:
+        raise ValueError(f"max_months must be >= 1, got {max_months}")
+
     from datetime import date  # noqa: PLC0415
 
     def _parse(s: str) -> date:
@@ -85,6 +91,9 @@ def _split_month_range(initial_month: str, final_month: str, max_months: int = 1
 
     start = _parse(initial_month)
     end = _parse(final_month)
+
+    if start > end:
+        raise ValueError(f"initial_month ({initial_month}) must be <= final_month ({final_month})")
 
     ranges: list[tuple[str, str]] = []
     cur = start
@@ -499,9 +508,9 @@ class VoltariumClient:
                 for contract_data in data.get("contratos", data.get("contrato", [])):
                     yield Contract.model_validate(contract_data)
 
-            page_index = data.get("indexProximaPagina")
-            if page_index is None:
-                break
+                page_index = data.get("indexProximaPagina")
+                if page_index is None:
+                    break
 
     async def get_contract(
         self,

--- a/tests/test_client/test_helpers.py
+++ b/tests/test_client/test_helpers.py
@@ -1,0 +1,49 @@
+"""Unit tests for client-level helper functions."""
+
+from voltarium.client import _split_month_range
+
+
+def test_same_month():
+    assert _split_month_range("2024-03", "2024-03") == [("2024-03", "2024-03")]
+
+
+def test_within_12_months():
+    result = _split_month_range("2024-01", "2024-12")
+    assert result == [("2024-01", "2024-12")]
+
+
+def test_exactly_13_months_splits_into_two():
+    result = _split_month_range("2024-01", "2025-01")
+    assert result == [("2024-01", "2024-12"), ("2025-01", "2025-01")]
+
+
+def test_multi_year_range():
+    result = _split_month_range("2020-01", "2026-03")
+    # Every window must be at most 12 months
+    for start, end in result:
+        sy, sm = map(int, start.split("-"))
+        ey, em = map(int, end.split("-"))
+        assert (ey - sy) * 12 + (em - sm) < 12
+
+    # Must cover the full range with no gaps
+    assert result[0][0] == "2020-01"
+    assert result[-1][1] == "2026-03"
+
+    for i in range(len(result) - 1):
+        _, window_end = result[i]
+        next_start, _ = result[i + 1]
+        ey, em = map(int, window_end.split("-"))
+        sy, sm = map(int, next_start.split("-"))
+        # next window starts exactly the month after current window ends
+        expected_next = (ey + 1, 1) if em == 12 else (ey, em + 1)
+        assert (sy, sm) == expected_next
+
+
+def test_year_boundary():
+    result = _split_month_range("2023-07", "2024-06")
+    assert result == [("2023-07", "2024-06")]
+
+
+def test_year_boundary_exceeds_12():
+    result = _split_month_range("2023-07", "2024-07")
+    assert result == [("2023-07", "2024-06"), ("2024-07", "2024-07")]

--- a/tests/test_client/test_helpers.py
+++ b/tests/test_client/test_helpers.py
@@ -1,5 +1,7 @@
 """Unit tests for client-level helper functions."""
 
+import pytest
+
 from voltarium.client import _split_month_range
 
 
@@ -47,3 +49,13 @@ def test_year_boundary():
 def test_year_boundary_exceeds_12():
     result = _split_month_range("2023-07", "2024-07")
     assert result == [("2023-07", "2024-06"), ("2024-07", "2024-07")]
+
+
+def test_inverted_range_raises():
+    with pytest.raises(ValueError, match="initial_month"):
+        _split_month_range("2024-06", "2024-01")
+
+
+def test_invalid_max_months_raises():
+    with pytest.raises(ValueError, match="max_months"):
+        _split_month_range("2024-01", "2024-12", max_months=0)

--- a/uv.lock
+++ b/uv.lock
@@ -817,7 +817,7 @@ wheels = [
 
 [[package]]
 name = "voltarium"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- CCEE rejects requests where `mesReferenciaInicial` to `mesReferenciaFinal` spans more than 12 months (`ERR_MES_REFERENCIA_INICIAL_DIFERENCA`)
- Added `_split_month_range()` helper that splits any YYYY-MM range into 12-month windows
- `list_migrations` and `list_contracts` now transparently iterate over windows — callers pass any date range and get back all results
- Bumped to **0.5.5**

## Test plan

- [ ] `tests/test_client/test_helpers.py` — 6 unit tests covering same month, within 12 months, exactly 13 months, multi-year (2020→2026), year boundary, year boundary exceeding 12
- [ ] `uv run ruff check && uv run ty check` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)