### PR TITLE
feat!: support CCEE migrations API V1.1 and V2 (breaking: default api_version is now v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,13 @@ task lint && task format && task typecheck
 
 **Alpha Release** - Core migration endpoints fully supported:
 
-✅ **Retailer Migrations** - Complete CRUD operations
+✅ **Retailer Migrations** - Complete CRUD operations, with V1/V1.1/V2 API version support (`api_version=`, defaults to `"v2"`)
 🚧 **Utility Migrations** - Under development
 📋 **Additional Endpoints** - [See roadmap](https://voltarium.github.io/voltarium-python/staging/#roadmap)
+
+> **1.0.0 note:** `VoltariumClient`'s default `api_version` is now `"v2"` (previously the only
+> option was CCEE's V1 migrations API). Pass `api_version="v1"` to keep the old behavior — see
+> [API Versioning](docs/endpoints.md#api-versioning-migrations).
 
 ## 🤝 Contributing
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -17,6 +17,7 @@ def __init__(
     base_url: str,
     client_id: str,
     client_secret: str,
+    api_version: Literal["v1", "v1.1", "v2"] = "v2",
     timeout: float = 30.0,
     max_retries: int = 3,
 ) -> None:
@@ -27,6 +28,8 @@ def __init__(
 - `base_url` (str): Base URL for the API
 - `client_id` (str): OAuth2 client ID
 - `client_secret` (str): OAuth2 client secret
+- `api_version` (`Literal["v1", "v1.1", "v2"]`, optional): CCEE migrations API generation to
+  target. Defaults to `"v2"` (the latest). See [API Versioning](#api-versioning-migrations) below.
 - `timeout` (float, optional): Request timeout in seconds. Defaults to 30.0
 - `max_retries` (int, optional): Maximum number of retries for failed requests. Defaults to 3
 
@@ -51,19 +54,67 @@ async with VoltariumClient(...) as client:
     pass
 ```
 
+## API Versioning (Migrations)
+
+CCEE's migrations API has three generations: `"v1"`, `"v1.1"`, and `"v2"`. Only the migrations
+endpoints (create/list/get/update/delete) are versioned — contracts and measurements are always
+`v1`. Pick a version once, at construction time, via `api_version`:
+
+```python
+client = VoltariumClient(..., api_version="v2")   # default
+client = VoltariumClient(..., api_version="v1.1")
+client = VoltariumClient(..., api_version="v1")    # pre-2.0 behavior
+```
+
+**`api_version` defaults to `"v2"` as of 2.0 — this is a breaking change from 1.x, which only
+supported `v1`.** Pass `api_version="v1"` to keep the old behavior.
+
+Not every operation has an endpoint at every version. Calls transparently fall back to the closest
+older version that does have one:
+
+| Operation | v1 | v1.1 | v2 |
+|-----------|----|----|----|
+| List | ✅ | ✅ | ✅ |
+| Create | ✅ | ✅ (same body as v1) | ✅ (`CreateMigrationRequestV2`) |
+| Get | ✅ | ✅ | ✅ |
+| Update | ✅ | falls back to v1 | ✅ (same body as v1) |
+| Delete | ✅ | falls back to v1 | falls back to v1 |
+
+**V1 → V1.1**: no request-shape change. Makes the standardized consumer-unit code mandatory and
+adds response-only fields (`process_siga_indicator`, on both `MigrationListItem` and `MigrationItem`).
+
+**V1 → V2 (CP7 rules)**: the create request shape changes — `denunciation_date` is removed and
+replaced by a required `utility_formalized` (`formalizacaoDistribuidora`, `"SIM"` or `"NAO"`) plus a
+required `consumer_unit_tariff_subgroup` (`subGrupoTarifarioUnidadeConsumidora`). Two more fields are
+conditionally required based on `utility_formalized`:
+
+- `formalization_date` (`dataFormalizacao`) — required when `utility_formalized="SIM"`, must be
+  omitted otherwise.
+- `migration_modality` (`modalidadeMigracao`, `"REGULAR"` or `"ANTECIPADA"`) — required when
+  `utility_formalized="NAO"`, must be omitted otherwise.
+
+Because the shape genuinely differs, V2 creates use a separate `CreateMigrationRequestV2` model
+(see [Create Migration (V2)](#create-migration-v2) below) instead of `CreateMigrationRequest`.
+`create_migration` raises `TypeError` if you pass the wrong model for the client's resolved version.
+Responses also gain `protocol_number`, `intended_utility_month`, `formalization_date`,
+`migration_modality`, `consumer_unit_tariff_subgroup`, and `utility_formalized`.
+
 ## Migration Endpoints (🇧🇷 Migracoes)
 
 The migration endpoints provide full CRUD (Create, Read, Update, Delete) operations for managing retailer migrations. All endpoints are asynchronous and include automatic authentication, error handling, and retry logic.
 
 ### Overview
 
+The path prefix (`/v1/`, `/v1.1/`, or `/v2/`) is chosen automatically based on the client's
+`api_version` — see [API Versioning](#api-versioning-migrations) above.
+
 | Operation | Method | Endpoint | Description |
 |-----------|--------|----------|-------------|
-| [List Migrations](#list-migrations) | GET | `/v1/varejista/migracoes` | List migrations with filtering and pagination |
-| [Create Migration](#create-migration) | POST | `/v1/varejista/migracoes` | Create a new migration |
-| [Get Migration](#get-migration) | GET | `/v1/varejista/migracoes/{id}` | Get a specific migration by ID |
-| [Update Migration](#update-migration) | PUT | `/v1/varejista/migracoes/{id}` | Update an existing migration |
-| [Delete Migration](#delete-migration) | DELETE | `/v1/varejista/migracoes/{id}` | Delete a migration |
+| [List Migrations](#list-migrations) | GET | `/{version}/varejista/migracoes` | List migrations with filtering and pagination |
+| [Create Migration](#create-migration) | POST | `/{version}/varejista/migracoes` | Create a new migration |
+| [Get Migration](#get-migration) | GET | `/{version}/varejista/migracoes/{id}` | Get a specific migration by ID |
+| [Update Migration](#update-migration) | PUT | `/{version}/varejista/migracoes/{id}` | Update an existing migration |
+| [Delete Migration](#delete-migration) | DELETE | `/v1/varejista/migracoes/{id}` | Delete a migration (no v1.1/v2 endpoint exists) |
 | [List Contracts](#list-contracts) | GET | `/v1/varejista/contratos` | List retailer contracts with filtering and pagination |
 | [Get Contract](#get-contract) | GET | `/v1/varejista/contratos/{id}` | Get a specific contract by ID |
 | [Create Contract](#create-contract) | POST | `/v1/varejista/contratos` | Create a retailer contract |
@@ -127,8 +178,17 @@ class MigrationListItem:
     comment: str | None
     supplier_agent_code: int | None
     reference_month: datetime
-    denunciation_date: datetime
+    denunciation_date: datetime | None  # absent on v1.1/v2 migrations formalized with the utility
     cer_celebration_id: str | None
+    # V1.1+
+    process_siga_indicator: str | None
+    # V2+ (CP7)
+    protocol_number: str | None
+    intended_utility_month: str | None
+    formalization_date: datetime | None
+    migration_modality: Literal["REGULAR", "ANTECIPADA"] | None
+    consumer_unit_tariff_subgroup: Literal["A2", "A3", "A3a", "A4", "AS", "B1", "B2", "B3", "B4"] | None
+    utility_formalized: Literal["SIM", "NAO"] | None
 ```
 
 ## Contracts Endpoints (🇧🇷 Contratos)
@@ -509,6 +569,63 @@ async def create_migration():
         except Exception as e:
             print(f"❌ Unexpected error: {e}")
 ```
+
+## Create Migration (V2)
+
+When the client resolves to `api_version="v2"` for creates (the default), `create_migration`
+expects a `CreateMigrationRequestV2` instead of `CreateMigrationRequest`.
+
+### Usage
+
+```python
+from voltarium import CreateMigrationRequestV2
+
+async with VoltariumClient(...) as client:  # api_version="v2" by default
+    request = CreateMigrationRequestV2(
+        consumer_unit_code="12345",
+        utility_agent_code=123,
+        document_type="CNPJ",
+        document_number="12345678901234",
+        retailer_agent_code=456,
+        reference_month="2024-01",
+        retailer_profile_code=789,
+        consumer_unit_email="contact@example.com",
+        consumer_unit_tariff_subgroup="A3a",
+        utility_formalized="SIM",
+        formalization_date="2024-01-15",   # required because utility_formalized == "SIM"
+        # migration_modality omitted — forbidden when utility_formalized == "SIM"
+        comment="Migration request comment",
+    )
+
+    migration = await client.create_migration(
+        migration_data=request,
+        agent_code="12345",
+        profile_code="67890"
+    )
+
+    print(f"Created migration: {migration.migration_id}")
+```
+
+### CreateMigrationRequestV2 Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `consumer_unit_code` | `str` | Yes | Consumer unit code |
+| `utility_agent_code` | `int \| str` | Yes | Utility agent code |
+| `document_type` | `Literal["CPF", "CNPJ"]` | Yes | Document type |
+| `document_number` | `str` | Conditional | Required for CNPJ, omit for CPF |
+| `retailer_agent_code` | `int \| str` | Yes | Retailer agent code |
+| `reference_month` | `str` | Yes | Reference month (YYYY-MM format) |
+| `retailer_profile_code` | `int \| str` | Yes | Retailer profile code |
+| `consumer_unit_email` | `str` | Yes | Consumer unit email |
+| `consumer_unit_tariff_subgroup` | `Literal["A2","A3","A3a","A4","AS","B1","B2","B3","B4"]` | Yes | Consumer unit tariff subgroup |
+| `utility_formalized` | `Literal["SIM", "NAO"]` | Yes | Whether formalized with the utility |
+| `formalization_date` | `str` | Conditional | Required (YYYY-MM-DD) when `utility_formalized="SIM"`; must be omitted otherwise |
+| `migration_modality` | `Literal["REGULAR", "ANTECIPADA"]` | Conditional | Required when `utility_formalized="NAO"`; must be omitted otherwise |
+| `comment` | `str` | No | Optional comment |
+
+Note: unlike `CreateMigrationRequest` (v1/v1.1), there is no `denunciation_date` field — CCEE
+replaced it with the `utility_formalized`/`formalization_date`/`migration_modality` workflow above.
 
 ## Get Migration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "voltarium"
-version = "0.5.5"
+version = "1.0.0"
 description = "Asynchronous Python client for CCEE (Brazilian Electric Energy Commercialization Chamber) API"
 authors = [
     { name = "joaodaher", email = "joao@daher.dev" }

--- a/src/voltarium/__init__.py
+++ b/src/voltarium/__init__.py
@@ -4,7 +4,12 @@ This package provides an asynchronous Python client for the CCEE
 (Brazilian Electric Energy Commercialization Chamber) API.
 """
 
-from voltarium.client import PRODUCTION_BASE_URL, SANDBOX_BASE_URL, VoltariumClient
+from voltarium.client import (
+    PRODUCTION_BASE_URL,
+    SANDBOX_BASE_URL,
+    MigrationApiVersion,
+    VoltariumClient,
+)
 from voltarium.exceptions import (
     AuthenticationError,
     NotFoundError,
@@ -17,6 +22,7 @@ from voltarium.models import (
     Contract,
     CreateContractRequest,
     CreateMigrationRequest,
+    CreateMigrationRequestV2,
     ListContractsParams,
     ListMigrationsParams,
     MigrationItem,
@@ -31,10 +37,12 @@ __all__ = [
     "VoltariumClient",
     "PRODUCTION_BASE_URL",
     "SANDBOX_BASE_URL",
+    "MigrationApiVersion",
     # Models
     "Contract",
     "CreateContractRequest",
     "CreateMigrationRequest",
+    "CreateMigrationRequestV2",
     "ListContractsParams",
     "ListMigrationsParams",
     "MigrationItem",

--- a/src/voltarium/client.py
+++ b/src/voltarium/client.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
 from types import TracebackType
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 import httpx
 from httpx import Response
@@ -22,6 +22,7 @@ from voltarium.models import (
     ContractFile,
     CreateContractRequest,
     CreateMigrationRequest,
+    CreateMigrationRequestV2,
     ListContractsParams,
     ListMeasurementsParams,
     ListMigrationsParams,
@@ -34,6 +35,21 @@ from voltarium.models import (
 
 PRODUCTION_BASE_URL = "https://api-abm.ccee.org.br"
 SANDBOX_BASE_URL = "https://sandbox-api-abm.ccee.org.br"
+
+# The three CCEE migrations API generations this client understands. Kept as a closed
+# Literal (not a bare str) so IDEs/type checkers surface the exact choices and reject typos.
+MigrationApiVersion = Literal["v1", "v1.1", "v2"]
+
+# Which migrations operations exist at each API version, per the CCEE Postman collection.
+# V1.1 has no distinct edit endpoint; neither V1.1 nor V2 documents a delete endpoint.
+_MIGRATION_ENDPOINT_VERSIONS: dict[str, tuple[MigrationApiVersion, ...]] = {
+    "list": ("v1", "v1.1", "v2"),
+    "create": ("v1", "v1.1", "v2"),
+    "get": ("v1", "v1.1", "v2"),
+    "update": ("v1", "v2"),
+    "delete": ("v1",),
+}
+_MIGRATION_VERSION_ORDER: tuple[MigrationApiVersion, ...] = ("v2", "v1.1", "v1")
 
 
 def _split_datetime_range_by_month(start_str: str, end_str: str) -> list[tuple[str, str]]:
@@ -114,6 +130,7 @@ class VoltariumClient:
         client_id: str,
         client_secret: str,
         base_url: str = PRODUCTION_BASE_URL,
+        api_version: MigrationApiVersion = "v2",
         timeout: float = 30.0,
         max_retries: int = 3,
     ) -> None:
@@ -123,6 +140,11 @@ class VoltariumClient:
             base_url: Base URL for the API
             client_id: OAuth2 client ID
             client_secret: OAuth2 client secret
+            api_version: CCEE migrations API generation to target ("v1", "v1.1", or "v2").
+                Defaults to "v2" (the latest). Operations without an endpoint at the
+                configured version transparently fall back to the closest older version
+                that has one (see `_MIGRATION_ENDPOINT_VERSIONS`). Pass "v1" to keep the
+                pre-2.0 behavior of this client.
             timeout: Request timeout in seconds
             max_retries: Maximum number of retries for failed requests
         """
@@ -130,6 +152,7 @@ class VoltariumClient:
         self.base_url = base_url.rstrip("/")
         self.client_id = client_id
         self.client_secret = client_secret
+        self.api_version = api_version
         self.timeout = timeout
         self.max_retries = max_retries
 
@@ -140,6 +163,19 @@ class VoltariumClient:
             follow_redirects=True,
         )
         self._token: Token | None = None
+
+    def _resolve_migration_version(self, operation: str) -> MigrationApiVersion:
+        """Resolve the actual API version to use for a migrations operation.
+
+        Falls back from `self.api_version` toward "v1" until it finds a version that
+        actually has an endpoint for this operation.
+        """
+        supported = _MIGRATION_ENDPOINT_VERSIONS[operation]
+        start = _MIGRATION_VERSION_ORDER.index(self.api_version)
+        for candidate in _MIGRATION_VERSION_ORDER[start:]:
+            if candidate in supported:
+                return candidate
+        return "v1"  # unreachable in practice: v1 supports every operation
 
     async def _refresh_token(self) -> None:
         """Get access token, refreshing if needed."""
@@ -301,6 +337,7 @@ class VoltariumClient:
             agent_code=str(agent_code),
             profile_code=str(profile_code),
         )
+        version = self._resolve_migration_version("list")
 
         for window_start, window_end in _split_month_range(initial_reference_month, final_reference_month):
             params_model = ListMigrationsParams(
@@ -315,7 +352,7 @@ class VoltariumClient:
                 _params.next_page_index = page_index
                 return await self._request(
                     method="GET",
-                    path="/v1/varejista/migracoes",
+                    path=f"/{version}/varejista/migracoes",
                     headers=headers_model.model_dump(by_alias=True),
                     params=_params.model_dump(by_alias=True, exclude_none=True),
                 )
@@ -334,32 +371,49 @@ class VoltariumClient:
 
     async def create_migration(
         self,
-        migration_data: CreateMigrationRequest,
+        migration_data: CreateMigrationRequest | CreateMigrationRequestV2,
         agent_code: str | int,
         profile_code: str | int,
     ) -> MigrationItem:
         """Create a new migration.
 
         Args:
-            migration_data: Migration data
+            migration_data: Migration data. Must be a `CreateMigrationRequestV2` when this
+                client resolves to API version "v2" for the create operation, or a
+                `CreateMigrationRequest` otherwise (v1/v1.1 share the same request shape).
             agent_code: Agent code
             profile_code: Profile code
 
         Returns:
             Created migration
+
+        Raises:
+            TypeError: If migration_data's type doesn't match the resolved API version.
         """
         # Create headers model
         headers_model = ApiHeaders(
             agent_code=str(agent_code),
             profile_code=str(profile_code),
         )
+        version = self._resolve_migration_version("create")
+
+        if version == "v2" and not isinstance(migration_data, CreateMigrationRequestV2):
+            raise TypeError(
+                "api_version resolved to 'v2' for create_migration; migration_data must be a "
+                "CreateMigrationRequestV2 instance."
+            )
+        if version != "v2" and not isinstance(migration_data, CreateMigrationRequest):
+            raise TypeError(
+                f"api_version resolved to {version!r} for create_migration; migration_data must be a "
+                "CreateMigrationRequest instance."
+            )
 
         # Use model_dump with by_alias=True to get Portuguese field names for the API
         json_data = migration_data.model_dump(by_alias=True, exclude_none=True)
 
         response = await self._request(
             method="POST",
-            path="/v1/varejista/migracoes",
+            path=f"/{version}/varejista/migracoes",
             headers=headers_model.model_dump(by_alias=True),
             json=json_data,
         )
@@ -387,10 +441,11 @@ class VoltariumClient:
             agent_code=str(agent_code),
             profile_code=str(profile_code),
         )
+        version = self._resolve_migration_version("get")
 
         response = await self._request(
             method="GET",
-            path=f"/v1/varejista/migracoes/{migration_id}",
+            path=f"/{version}/varejista/migracoes/{migration_id}",
             headers=headers_model.model_dump(by_alias=True),
         )
 
@@ -422,13 +477,14 @@ class VoltariumClient:
             agent_code=str(agent_code),
             profile_code=str(profile_code),
         )
+        version = self._resolve_migration_version("update")
 
         # Use model_dump with by_alias=True to get Portuguese field names for the API
         json_data = migration_data.model_dump(by_alias=True, exclude_none=True)
 
         response = await self._request(
             method="PUT",
-            path=f"/v1/varejista/migracoes/{migration_id}",
+            path=f"/{version}/varejista/migracoes/{migration_id}",
             headers=headers_model.model_dump(by_alias=True),
             json=json_data,
         )
@@ -453,10 +509,11 @@ class VoltariumClient:
             agent_code=str(agent_code),
             profile_code=str(profile_code),
         )
+        version = self._resolve_migration_version("delete")
 
         await self._request(
             method="DELETE",
-            path=f"/v1/varejista/migracoes/{migration_id}",
+            path=f"/{version}/varejista/migracoes/{migration_id}",
             headers=headers_model.model_dump(by_alias=True),
         )
 

--- a/src/voltarium/factories/__init__.py
+++ b/src/voltarium/factories/__init__.py
@@ -5,6 +5,7 @@ from .measurements import ListMeasurementsParamsFactory, MeasurementFactory
 from .migration import (
     BaseMigrationFactory,
     CreateMigrationRequestFactory,
+    CreateMigrationRequestV2Factory,
     MigrationItemFactory,
     MigrationListItemFactory,
     UpdateMigrationRequestFactory,
@@ -18,6 +19,7 @@ __all__ = [
     "BaseMigrationFactory",
     "MigrationListItemFactory",
     "CreateMigrationRequestFactory",
+    "CreateMigrationRequestV2Factory",
     "UpdateMigrationRequestFactory",
     "MigrationItemFactory",
     "CreateContractRequestFactory",

--- a/src/voltarium/factories/contracts.py
+++ b/src/voltarium/factories/contracts.py
@@ -23,7 +23,12 @@ class CreateContractRequestFactory(factory.Factory):
 
     utility_agent_code = factory.LazyAttribute(lambda obj: obj.sandbox_utility.agent_code)
     consumer_unit_code = factory.LazyAttribute(
-        lambda obj: generate_consumer_unit_code(f"{obj.sandbox_utility.agent_code}{random.randint(1000, 9999)}")
+        # Wide (7-digit) suffix range: the shared CCEE sandbox accumulates consumer units
+        # across every dev/CI run, so a narrow range (e.g. 1000-9999) collides with
+        # previously-created active migrations often enough to make tests flaky.
+        lambda obj: generate_consumer_unit_code(
+            f"{obj.sandbox_utility.agent_code}{random.randint(1_000_000, 9_999_999)}"
+        )
     )
     consumer_unit_address = factory.Faker("address")
     consumer_unit_name = factory.Faker("company")

--- a/src/voltarium/factories/migration.py
+++ b/src/voltarium/factories/migration.py
@@ -48,7 +48,10 @@ class BaseMigrationFactory(factory.Factory):
     # Required fields
     migration_id = factory.Faker("uuid4")
     consumer_unit_code = factory.LazyAttribute(
-        lambda obj: generate_consumer_unit_code(f"{obj.utility_agent_code}{random.randint(1000, 9999)}")
+        # Wide (7-digit) suffix range: the shared CCEE sandbox accumulates consumer units
+        # across every dev/CI run, so a narrow range (e.g. 1000-9999) collides with
+        # previously-created active migrations often enough to make tests flaky.
+        lambda obj: generate_consumer_unit_code(f"{obj.utility_agent_code}{random.randint(1_000_000, 9_999_999)}")
     )
     utility_agent_consumer_unit_code = factory.Faker("numerify", text="###")
     document_type = factory.Faker("random_element", elements=("CPF", "CNPJ"))
@@ -158,7 +161,10 @@ class CreateMigrationRequestFactory(factory.Factory):
         return utility.agent_code
 
     consumer_unit_code = factory.LazyAttribute(
-        lambda obj: generate_consumer_unit_code(f"{obj.utility_agent_code}{random.randint(1000, 9999)}")
+        # Wide (7-digit) suffix range: the shared CCEE sandbox accumulates consumer units
+        # across every dev/CI run, so a narrow range (e.g. 1000-9999) collides with
+        # previously-created active migrations often enough to make tests flaky.
+        lambda obj: generate_consumer_unit_code(f"{obj.utility_agent_code}{random.randint(1_000_000, 9_999_999)}")
     )
     document_type = FuzzyChoice(["CNPJ", "CPF"])
 
@@ -208,7 +214,10 @@ class CreateMigrationRequestV2Factory(factory.Factory):
         return utility.agent_code
 
     consumer_unit_code = factory.LazyAttribute(
-        lambda obj: generate_consumer_unit_code(f"{obj.utility_agent_code}{random.randint(1000, 9999)}")
+        # Wide (7-digit) suffix range: the shared CCEE sandbox accumulates consumer units
+        # across every dev/CI run, so a narrow range (e.g. 1000-9999) collides with
+        # previously-created active migrations often enough to make tests flaky.
+        lambda obj: generate_consumer_unit_code(f"{obj.utility_agent_code}{random.randint(1_000_000, 9_999_999)}")
     )
     document_type = FuzzyChoice(["CNPJ", "CPF"])
 

--- a/src/voltarium/factories/migration.py
+++ b/src/voltarium/factories/migration.py
@@ -8,10 +8,11 @@ import factory
 from factory.fuzzy import FuzzyChoice
 from faker import Faker
 
-from voltarium.models.constants import Submarket
+from voltarium.models.constants import MigrationStatus, Submarket
 from voltarium.models.migration import (
     BaseMigration,
     CreateMigrationRequest,
+    CreateMigrationRequestV2,
     MigrationItem,
     MigrationListItem,
     UpdateMigrationRequest,
@@ -62,7 +63,7 @@ class BaseMigrationFactory(factory.Factory):
         return None
 
     request_date = factory.Faker("date_time_this_year")
-    migration_status = factory.Faker("random_element", elements=("PENDENTE", "APROVADA", "REJEITADA"))
+    migration_status = FuzzyChoice(MigrationStatus)
     consumer_unit_email = factory.Faker("email")
     submarket = FuzzyChoice(Submarket)
 
@@ -73,6 +74,19 @@ class BaseMigrationFactory(factory.Factory):
     justification = factory.Faker("text", max_nb_chars=200)
     validation_date = factory.Faker("date_time_this_year")
     comment = factory.Faker("text", max_nb_chars=500)
+
+    # V1.1 fields (response-only)
+    process_siga_indicator = factory.Faker("word")
+
+    # V2 fields (response-only)
+    protocol_number = factory.Faker("numerify", text="PROT-####")
+    intended_utility_month = factory.LazyFunction(
+        lambda: (datetime.now() + timedelta(days=random.randint(30, 90))).strftime("%Y-%m")
+    )
+    formalization_date = factory.Faker("date_time_this_year")
+    migration_modality = factory.Faker("random_element", elements=("REGULAR", "ANTECIPADA"))
+    consumer_unit_tariff_subgroup = FuzzyChoice(["A2", "A3", "A3a", "A4", "AS", "B1", "B2", "B3", "B4"])
+    utility_formalized = factory.Faker("random_element", elements=("SIM", "NAO"))
 
 
 class MigrationListItemFactory(BaseMigrationFactory):
@@ -106,7 +120,7 @@ class MigrationItemFactory(BaseMigrationFactory):
 
     # MigrationItem specific fields
     @factory.lazy_attribute
-    def reference_date(obj: Any) -> datetime:
+    def reference_month(obj: Any) -> datetime:
         # Generate a future month (1-3 months ahead)
         future_date = datetime.now() + timedelta(days=random.randint(30, 90))
         return future_date.replace(day=1)  # First day of the month
@@ -167,6 +181,68 @@ class CreateMigrationRequestFactory(factory.Factory):
         return future_date.strftime("%Y-%m-%d")
 
     consumer_unit_email = factory.Faker("email")
+    comment = factory.Faker("text", max_nb_chars=500)
+
+
+class CreateMigrationRequestV2Factory(factory.Factory):
+    """Factory for CreateMigrationRequestV2 model (CP7 rules)."""
+
+    class Meta:
+        model = CreateMigrationRequestV2
+
+    class Params:
+        sandbox_agent_credentials = FuzzyChoice(RETAILERS)
+
+    # Generate real agent credentials for testing
+    @factory.lazy_attribute
+    def retailer_agent_code(obj: Any) -> int:
+        return obj.sandbox_agent_credentials.agent_code
+
+    @factory.lazy_attribute
+    def retailer_profile_code(obj: Any) -> int:
+        return random.choice(obj.sandbox_agent_credentials.profiles)
+
+    @factory.lazy_attribute
+    def utility_agent_code(obj: Any) -> int:
+        utility = random.choice(UTILITIES)
+        return utility.agent_code
+
+    consumer_unit_code = factory.LazyAttribute(
+        lambda obj: generate_consumer_unit_code(f"{obj.utility_agent_code}{random.randint(1000, 9999)}")
+    )
+    document_type = FuzzyChoice(["CNPJ", "CPF"])
+
+    @factory.lazy_attribute
+    def document_number(obj: Any) -> str | None:
+        if obj.document_type == "CPF":
+            return None
+        return fake_br.cnpj().replace(".", "").replace("/", "").replace("-", "")
+
+    @factory.lazy_attribute
+    def reference_month(obj: Any) -> str:
+        # Generate a future month (1-3 months ahead) in YYYY-MM format
+        future_date = datetime.now() + timedelta(days=random.randint(30, 90))
+        return future_date.strftime("%Y-%m")
+
+    consumer_unit_email = factory.Faker("email")
+    consumer_unit_tariff_subgroup = FuzzyChoice(["A2", "A3", "A3a", "A4", "AS", "B1", "B2", "B3", "B4"])
+    utility_formalized = FuzzyChoice(["SIM", "NAO"])
+
+    @factory.lazy_attribute
+    def formalization_date(obj: Any) -> str | None:
+        # Required (and only valid) when utility_formalized == "SIM"
+        if obj.utility_formalized != "SIM":
+            return None
+        future_date = datetime.now() + timedelta(days=random.randint(30, 60))
+        return future_date.strftime("%Y-%m-%d")
+
+    @factory.lazy_attribute
+    def migration_modality(obj: Any) -> str | None:
+        # Required (and only valid) when utility_formalized == "NAO"
+        if obj.utility_formalized != "NAO":
+            return None
+        return random.choice(["REGULAR", "ANTECIPADA"])
+
     comment = factory.Faker("text", max_nb_chars=500)
 
 

--- a/src/voltarium/models/__init__.py
+++ b/src/voltarium/models/__init__.py
@@ -12,6 +12,7 @@ from .measurements import Measurement
 from .migration import (
     BaseMigration,
     CreateMigrationRequest,
+    CreateMigrationRequestV2,
     MigrationItem,
     MigrationListItem,
     UpdateMigrationRequest,
@@ -31,6 +32,7 @@ __all__ = [
     "ContractFile",
     "CreateContractRequest",
     "CreateMigrationRequest",
+    "CreateMigrationRequestV2",
     "LegalRepresentative",
     "LegalRepresentativeWrite",
     "ListContractsParams",

--- a/src/voltarium/models/migration.py
+++ b/src/voltarium/models/migration.py
@@ -38,6 +38,31 @@ class BaseMigration(BaseModel):
     consumer_unit_email: str = Field(alias="emailUnidadeConsumidora", description="Consumer unit email")
     comment: str | None = Field(default=None, alias="comentario", description="Comment")
 
+    # V1.1 fields (response-only; absent on V1 and V2 responses)
+    process_siga_indicator: str | None = Field(
+        default=None, alias="indicadorProcessoSiga", description="Siga process indicator (V1.1+)"
+    )
+
+    # V2 fields (response-only; absent on V1 and V1.1 responses)
+    protocol_number: str | None = Field(
+        default=None, alias="numeroProtocolo", description="Utility protocol number (V2+)"
+    )
+    intended_utility_month: str | None = Field(
+        default=None, alias="mesPretendidoConcessionaria", description="Intended utility migration month (V2+)"
+    )
+    formalization_date: datetime | None = Field(
+        default=None, alias="dataFormalizacao", description="Utility formalization date (V2+)"
+    )
+    migration_modality: Literal["REGULAR", "ANTECIPADA"] | None = Field(
+        default=None, alias="modalidadeMigracao", description="Migration modality (V2+)"
+    )
+    consumer_unit_tariff_subgroup: Literal["A2", "A3", "A3a", "A4", "AS", "B1", "B2", "B3", "B4"] | None = Field(
+        default=None, alias="subGrupoTarifarioUnidadeConsumidora", description="Consumer unit tariff subgroup (V2+)"
+    )
+    utility_formalized: Literal["SIM", "NAO"] | None = Field(
+        default=None, alias="formalizacaoDistribuidora", description="Whether formalized with the utility (V2+)"
+    )
+
 
 class MigrationListItem(BaseMigration):
     """Migration list item model for list operations."""
@@ -49,7 +74,9 @@ class MigrationListItem(BaseMigration):
         default=None, alias="codigoAgenteSupridora", description="Supplier agent code"
     )
     reference_month: datetime = Field(alias="mesReferencia", description="Reference month")
-    denunciation_date: datetime = Field(alias="dataDenuncia", description="Denunciation date")
+    # Optional: absent on V1.1/V2 migrations created via the formalizacaoDistribuidora workflow,
+    # which supersedes dataDenuncia (V2's create request drops the field entirely).
+    denunciation_date: datetime | None = Field(default=None, alias="dataDenuncia", description="Denunciation date")
     cer_celebration_id: str | None = Field(default=None, alias="idCelebracaoCER", description="CER celebration ID")
 
 
@@ -133,6 +160,110 @@ class CreateMigrationRequest(BaseModel):
         except ValueError as exc:
             raise ValueError("denunciation_date must be in the format YYYY-MM-DD") from exc
         return v
+
+
+class CreateMigrationRequestV2(BaseModel):
+    """Request model for creating a migration (V2, CP7 rules)."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    consumer_unit_code: str = Field(serialization_alias="codigoUnidadeConsumidora", description="Consumer unit code")
+    utility_agent_code: int | str = Field(
+        serialization_alias="codigoAgenteConcessionaria", description="Utility agent code"
+    )
+    document_type: Literal["CPF", "CNPJ"] = Field(serialization_alias="tipoDocumento", description="Document type")
+    document_number: str | None = Field(
+        default=None,
+        serialization_alias="numeroDocumento",
+        description="Document number (omit for CPF requests)",
+    )
+    retailer_agent_code: int | str = Field(
+        serialization_alias="codigoAgenteVarejista", description="Retailer agent code"
+    )
+    reference_month: str = Field(serialization_alias="mesReferencia", description="Reference month (YYYY-MM)")
+    retailer_profile_code: int | str = Field(
+        serialization_alias="codigoPerfilVarejista", description="Retailer profile code"
+    )
+    consumer_unit_email: str = Field(serialization_alias="emailUnidadeConsumidora", description="Consumer unit email")
+    consumer_unit_tariff_subgroup: Literal["A2", "A3", "A3a", "A4", "AS", "B1", "B2", "B3", "B4"] = Field(
+        serialization_alias="subGrupoTarifarioUnidadeConsumidora", description="Consumer unit tariff subgroup"
+    )
+    utility_formalized: Literal["SIM", "NAO"] = Field(
+        serialization_alias="formalizacaoDistribuidora", description="Whether formalized with the utility"
+    )
+    formalization_date: str | None = Field(
+        default=None,
+        serialization_alias="dataFormalizacao",
+        description=(
+            "Utility formalization date (YYYY-MM-DD); required when utility_formalized is 'SIM', "
+            "must be omitted otherwise"
+        ),
+    )
+    migration_modality: Literal["REGULAR", "ANTECIPADA"] | None = Field(
+        default=None,
+        serialization_alias="modalidadeMigracao",
+        description="Migration modality; required when utility_formalized is 'NAO', must be omitted otherwise",
+    )
+    comment: str | None = Field(default=None, serialization_alias="comentario", description="Comment")
+
+    @field_validator("document_number", mode="before")
+    def normalize_document_number(cls, v: str | None) -> str | None:
+        """Normalize document number format."""
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return None
+
+        digits = "".join(filter(str.isdigit, str(v)))
+        if not digits:
+            raise ValueError("document_number must be a number")
+        return digits
+
+    @model_validator(mode="after")
+    def validate_document_length(self) -> Self:
+        document_type = self.document_type
+        document_number = self.document_number
+        if document_type == "CPF":
+            if document_number is not None:
+                raise ValueError("document_number must be omitted when document_type is CPF")
+            return self
+        if document_type == "CNPJ" and (document_number is None or len(document_number) != 14):
+            msg = "CNPJ numbers must contain exactly 14 digits"
+            raise ValueError(msg)
+        return self
+
+    @field_validator("reference_month")
+    def validate_reference_month(cls, v: str) -> str:
+        """Validate reference month format."""
+        try:
+            datetime.strptime(v, "%Y-%m")
+        except ValueError as exc:
+            raise ValueError("reference_month must be in the format YYYY-MM") from exc
+        return v
+
+    @field_validator("formalization_date")
+    def validate_formalization_date(cls, v: str | None) -> str | None:
+        """Validate formalization date format."""
+        if v is None:
+            return None
+        try:
+            datetime.strptime(v, "%Y-%m-%d")
+        except ValueError as exc:
+            raise ValueError("formalization_date must be in the format YYYY-MM-DD") from exc
+        return v
+
+    @model_validator(mode="after")
+    def validate_formalization_fields(self) -> Self:
+        """Enforce the CP7 conditional rules tying formalization fields together."""
+        if self.utility_formalized == "SIM":
+            if self.formalization_date is None:
+                raise ValueError("formalization_date is required when utility_formalized is 'SIM'")
+            if self.migration_modality is not None:
+                raise ValueError("migration_modality must be omitted when utility_formalized is 'SIM'")
+        else:
+            if self.migration_modality is None:
+                raise ValueError("migration_modality is required when utility_formalized is 'NAO'")
+            if self.formalization_date is not None:
+                raise ValueError("formalization_date must be omitted when utility_formalized is 'NAO'")
+        return self
 
 
 class UpdateMigrationRequest(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,43 @@ def utility() -> SandboxAgentCredentials:
 
 @pytest.fixture()
 async def client(retailer: SandboxAgentCredentials) -> AsyncGenerator[VoltariumClient]:
+    # Pinned to "v1" explicitly: these are the pre-existing integration tests, written
+    # against V1 migrations behavior. VoltariumClient's own default is "v2" as of the
+    # V1.1/V2 support work; version-specific behavior is covered by the client_v1_1/
+    # client_v2 fixtures below.
     client = VoltariumClient(
         base_url=SANDBOX_BASE_URL,
         client_id=retailer.client_id,
         client_secret=retailer.client_secret,
+        api_version="v1",
+    )
+    try:
+        yield client
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.fixture()
+async def client_v1_1(retailer: SandboxAgentCredentials) -> AsyncGenerator[VoltariumClient]:
+    client = VoltariumClient(
+        base_url=SANDBOX_BASE_URL,
+        client_id=retailer.client_id,
+        client_secret=retailer.client_secret,
+        api_version="v1.1",
+    )
+    try:
+        yield client
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.fixture()
+async def client_v2(retailer: SandboxAgentCredentials) -> AsyncGenerator[VoltariumClient]:
+    client = VoltariumClient(
+        base_url=SANDBOX_BASE_URL,
+        client_id=retailer.client_id,
+        client_secret=retailer.client_secret,
+        api_version="v2",
     )
     try:
         yield client

--- a/tests/test_client/test_migration_versioning.py
+++ b/tests/test_client/test_migration_versioning.py
@@ -1,0 +1,179 @@
+"""Tests for the V1/V1.1/V2 migrations API version selection and fallback logic."""
+
+from datetime import timedelta
+
+import pytest
+
+from voltarium.client import MigrationApiVersion, VoltariumClient
+from voltarium.factories import (
+    CreateMigrationRequestFactory,
+    CreateMigrationRequestV2Factory,
+    UpdateMigrationRequestFactory,
+)
+from voltarium.models import CreateMigrationRequest, CreateMigrationRequestV2, MigrationItem, MigrationListItem
+from voltarium.sandbox import SandboxAgentCredentials
+
+# --- Offline unit tests: no network call is made, so no sandbox credentials needed ---
+
+
+def _client(api_version: MigrationApiVersion) -> VoltariumClient:
+    return VoltariumClient(client_id="unit-test", client_secret="unit-test", api_version=api_version)
+
+
+def test_resolve_migration_version_v2_default_and_fallback() -> None:
+    client = _client("v2")
+    assert client._resolve_migration_version("list") == "v2"
+    assert client._resolve_migration_version("create") == "v2"
+    assert client._resolve_migration_version("get") == "v2"
+    assert client._resolve_migration_version("update") == "v2"
+    # No V2 (or V1.1) delete endpoint documented -> falls back all the way to v1
+    assert client._resolve_migration_version("delete") == "v1"
+
+
+def test_resolve_migration_version_v1_1_fallback() -> None:
+    client = _client("v1.1")
+    assert client._resolve_migration_version("list") == "v1.1"
+    assert client._resolve_migration_version("create") == "v1.1"
+    assert client._resolve_migration_version("get") == "v1.1"
+    # No distinct V1.1 edit endpoint -> falls back to v1
+    assert client._resolve_migration_version("update") == "v1"
+    assert client._resolve_migration_version("delete") == "v1"
+
+
+def test_resolve_migration_version_v1_no_fallback_needed() -> None:
+    client = _client("v1")
+    for operation in ("list", "create", "get", "update", "delete"):
+        assert client._resolve_migration_version(operation) == "v1"
+
+
+async def test_create_migration_v2_client_rejects_v1_request_shape() -> None:
+    client = _client("v2")
+    with pytest.raises(TypeError):
+        await client.create_migration(
+            CreateMigrationRequestFactory.build(),
+            agent_code=1,
+            profile_code=1,
+        )
+
+
+async def test_create_migration_v1_client_rejects_v2_request_shape() -> None:
+    client = _client("v1")
+    with pytest.raises(TypeError):
+        await client.create_migration(
+            CreateMigrationRequestV2Factory.build(),
+            agent_code=1,
+            profile_code=1,
+        )
+
+
+def test_create_migration_request_v2_model_shape() -> None:
+    """Sanity-check the factory produces a model matching the documented V2 body."""
+    request = CreateMigrationRequestV2Factory.build()
+    assert isinstance(request, CreateMigrationRequestV2)
+    dumped = request.model_dump(by_alias=True, exclude_none=True)
+    assert "subGrupoTarifarioUnidadeConsumidora" in dumped
+    assert "formalizacaoDistribuidora" in dumped
+    assert "dataDenuncia" not in dumped  # dropped in V2
+
+
+def test_create_migration_request_v1_still_requires_denunciation_date() -> None:
+    request = CreateMigrationRequestFactory.build()
+    assert isinstance(request, CreateMigrationRequest)
+    dumped = request.model_dump(by_alias=True, exclude_none=True)
+    assert "dataDenuncia" in dumped
+
+
+# --- Sandbox integration tests: exercise the actual V1.1/V2 endpoints end-to-end ---
+
+
+async def test_create_and_get_migration_v2(
+    client_v2: VoltariumClient,
+    retailer: SandboxAgentCredentials,
+    utility: SandboxAgentCredentials,
+) -> None:
+    """Create a migration via the V2 endpoint and confirm CP7 fields round-trip."""
+    profile_id = retailer.profiles[0]
+
+    created = await client_v2.create_migration(
+        migration_data=CreateMigrationRequestV2Factory.build(
+            retailer_agent_code=retailer.agent_code,
+            retailer_profile_code=profile_id,
+            utility_agent_code=utility.agent_code,
+        ),
+        agent_code=retailer.agent_code,
+        profile_code=profile_id,
+    )
+    assert isinstance(created, MigrationItem)
+
+    fetched = await client_v2.get_migration(
+        migration_id=created.migration_id,
+        agent_code=retailer.agent_code,
+        profile_code=profile_id,
+    )
+    assert isinstance(fetched, MigrationItem)
+    assert fetched.migration_id == created.migration_id
+
+
+async def test_list_migrations_v1_1(
+    client_v1_1: VoltariumClient,
+    retailer: SandboxAgentCredentials,
+    utility: SandboxAgentCredentials,
+) -> None:
+    """V1.1 create/list share V1's request shape; only the path and response fields differ."""
+    profile_id = retailer.profiles[0]
+
+    created = await client_v1_1.create_migration(
+        migration_data=CreateMigrationRequestFactory.build(
+            retailer_agent_code=retailer.agent_code,
+            retailer_profile_code=profile_id,
+            utility_agent_code=utility.agent_code,
+        ),
+        agent_code=retailer.agent_code,
+        profile_code=profile_id,
+    )
+    assert isinstance(created, MigrationItem)
+
+    initial_month = created.reference_month.strftime("%Y-%m")
+    results = [
+        m
+        async for m in client_v1_1.list_migrations(
+            initial_reference_month=initial_month,
+            final_reference_month=initial_month,
+            agent_code=retailer.agent_code,
+            profile_code=profile_id,
+        )
+    ]
+    assert any(m.migration_id == created.migration_id for m in results)
+    for m in results:
+        assert isinstance(m, MigrationListItem)
+
+
+async def test_update_migration_v1_1_falls_back_to_v1_endpoint(
+    client_v1_1: VoltariumClient,
+    retailer: SandboxAgentCredentials,
+    utility: SandboxAgentCredentials,
+) -> None:
+    """V1.1 has no distinct edit endpoint, so update_migration must still work via V1's."""
+    profile_id = retailer.profiles[0]
+
+    created = await client_v1_1.create_migration(
+        migration_data=CreateMigrationRequestFactory.build(
+            retailer_agent_code=retailer.agent_code,
+            retailer_profile_code=profile_id,
+            utility_agent_code=utility.agent_code,
+        ),
+        agent_code=retailer.agent_code,
+        profile_code=profile_id,
+    )
+
+    future_month = created.reference_month + timedelta(days=60)
+    updated = await client_v1_1.update_migration(
+        migration_id=created.migration_id,
+        migration_data=UpdateMigrationRequestFactory.build(
+            retailer_profile_code=profile_id,
+            reference_month=future_month.strftime("%Y-%m"),
+        ),
+        agent_code=retailer.agent_code,
+        profile_code=profile_id,
+    )
+    assert isinstance(updated, MigrationItem)

--- a/uv.lock
+++ b/uv.lock
@@ -817,7 +817,7 @@ wheels = [
 
 [[package]]
 name = "voltarium"
-version = "0.5.5"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Adds `api_version: Literal["v1", "v1.1", "v2"]` to `VoltariumClient`, chosen once at construction (defaults to `"v2"`, the latest CCEE migrations API generation). Per-operation fallback resolves toward `v1` for operations without an endpoint at the configured version (no distinct V1.1 edit endpoint, no V1.1/V2 delete endpoint).
- New `CreateMigrationRequestV2` model for V2's CP7 create body (drops `denunciation_date`, adds required `consumer_unit_tariff_subgroup`/`utility_formalized` plus the conditional `formalization_date`/`migration_modality` pair). `create_migration` raises `TypeError` locally (no network call) if the wrong request model is passed for the resolved version.
- `MigrationListItem`/`MigrationItem` gained the new V1.1/V2 response-only fields; `MigrationListItem.denunciation_date` is now optional — verified against the live CCEE sandbox that it's genuinely absent on V1.1/V2-created migrations.
- Bumped package version to `1.0.0` to signal the breaking default-version change per semver.
- Updated `docs/endpoints.md` and `README.md` with the new versioning behavior.

**BREAKING CHANGE:** `VoltariumClient`'s default `api_version` is now `"v2"` instead of the previous v1-only behavior. Pass `api_version="v1"` to keep the old behavior.

## Test plan
- [x] `uv run ruff check .` / `uv run ruff format --check .` — pass
- [x] `uv run ty check` — pass
- [x] `uv run pytest` — 52 passed; 1 pre-existing flaky sandbox-state test unrelated to this change (verified it fails identically on unmodified `main`)
- [x] New `tests/test_client/test_migration_versioning.py` covers the fallback resolver, the `TypeError` guard (offline), and live sandbox round-trips for V1.1 (create/list/update-fallback) and V2 (create/get)

🤖 Generated with [Claude Code](https://claude.com/claude-code)